### PR TITLE
respect `min` in TOC indentation

### DIFF
--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -45,7 +45,7 @@ generateToc = (headers, options) ->
       options.min <= header.level <= options.max
 
     .map ({level, title, link}) ->
-      indent = indentBase.repeat(level-1)
+      indent = indentBase.repeat(level-options.min)
       if options.link
         "#{indent}- [#{title}](##{link})"
       else


### PR DESCRIPTION
Btw, @t9md, kudos for being the only Markdown TOC package that ignores comments in code fences properly! 😜 

FIXES #12