### PR TITLE
Lets Atom handle the indenting

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,7 @@ const {Range} = require('atom')
 const TOC_END = '<!-- TOC END -->'
 const TOC_START_REGEXP = /<!-- TOC START (.*)?-->/i
 const TOC_END_REGEXP = new RegExp(`${_.escapeRegExp(TOC_END)}`, 'i')
+indents = []
 
 // TOC generation
 // -------------------------
@@ -43,18 +44,18 @@ function injectTitleAndLink (headers) {
   }
 }
 
-function buildTocText (headers, options) {
+function buildTocText (headers, range, options) {
   injectTitleAndLink(headers)
 
-  const indentBase = '  '
   return headers
     .filter(header => options.min <= header.level && header.level <= options.max)
-    .map(header => {
+    .map((header, index) => {
+      indents.push({ 'row': range.start.row+index+1, 'level': header.level - options.min })
       const indent = indentBase.repeat(header.level - options.min)
       if (options.link) {
-        return `${indent}- [${header.title}](#${header.link})`
+        return `- [${header.title}](#${header.link})`
       } else {
-        return `${indent}- [${header.title}]`
+        return `- [${header.title}]`
       }
     })
     .join('\n')
@@ -128,7 +129,7 @@ function insertToc (editor, range, options = {}) {
 
   let toc = ''
   toc += `<!-- TOC START ${serializeTocOptions(options)} -->\n`
-  toc += buildTocText(scanHeaders(editor), options) + '\n\n'
+  toc += buildTocText(scanHeaders(editor), range, options) + '\n\n'
   toc += TOC_END + (range.isEmpty() ? '\n\n' : '')
 
   const bufferPositionByCursor = new Map()
@@ -143,6 +144,8 @@ function insertToc (editor, range, options = {}) {
   editor.setTextInBufferRange(range, toc)
   editor.buffer.groupLastChanges()
 
+  addIndents(editor)
+
   // Restore oiginal cursor position
   for (const cursor of editor.getCursors()) {
     const point = bufferPositionByCursor.get(cursor)
@@ -150,6 +153,14 @@ function insertToc (editor, range, options = {}) {
       cursor.setBufferPosition(point)
     }
   }
+}
+
+function addIndents(editor)
+{
+  for (indent of indents) {
+    editor.setIndentationForBufferRow(indent.row, indent.level)
+  }
+  indents = []
 }
 
 function insertTocAtPoint (editor, point) {


### PR DESCRIPTION
This isn't the pretty way, but it's a quick way to let atom handle the indenting. Why is the beneficial? It uses the tab settings of the editor. For example, someone may want hard tabs. Or, like myself, someone may use 4 spaces or a different amount of spaces per tab.