### PR TITLE
:bug: Fix subscription when closing/re-opening a tab

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -32,10 +32,7 @@ module.exports = {
       atom.workspace.observeTextEditors(editor => {
         if (!isMarkdownEditor(editor)) return
         const URI = editor.getURI()
-
-        if (!this.subscriptionByURL.has(URI)) {
-          this.subscriptionByURL.set(URI, editor.buffer.onWillSave(() => getUtils().updateToc(editor)))
-        }
+        this.subscriptionByURL.set(URI, editor.buffer.onWillSave(() => getUtils().updateToc(editor)))
       })
     )
   },


### PR DESCRIPTION
When closing/re-opening a markdown tab, the subscription was not re-written. 
This means that the old callback was called with the old buffer that had been destroyed. 

The ToC was not updated until Atom was closed and re-opened.